### PR TITLE
setup.py fails because README.txt no longer exists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
       author='Tim Golden',
       author_email='mail@timgolden.me.uk',
       description='Python tools for the Windows sysadmin',
-      long_description=open ("README.txt").read (),
+      long_description=open ("README.rst").read (),
       classifiers=[
           'Development Status :: 4 - Beta',
           'Environment :: Console',


### PR DESCRIPTION
At some point it looks like you changed README.txt to README.rst, but the setup.py reference to it wasn't updated so an IOError occurs while running setup. I just noticed this at work while trying to use winsys in our buildout :)
