### PR TITLE
Add README.rst to the MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.txt
+include README.rst
 include setup.py
 recursive-include winsys *.py
 recursive-include docs *.rst


### PR DESCRIPTION
Sorry for more noise: just noticed that README.rst wasn't being added to sdist since it's now an rst instead of txt.

I didn't add it as *.rst on purpose, just explicitly adding README.rst since that's the only rst file and I'm not sure if other rst files being picked up might screw anything up.
